### PR TITLE
Enable auto login after first login.

### DIFF
--- a/app/src/main/java/co/tinode/tindroid/LoginFragment.java
+++ b/app/src/main/java/co/tinode/tindroid/LoginFragment.java
@@ -159,6 +159,7 @@ public class LoginFragment extends Fragment implements View.OnClickListener {
                                     bundle.putBoolean(ContentResolver.SYNC_EXTRAS_EXPEDITED, true);
                                     ContentResolver.requestSync(acc, Utils.SYNC_AUTHORITY, bundle);
                                     ContentResolver.setSyncAutomatically(acc, Utils.SYNC_AUTHORITY, true);
+                                    tinode.setAutoLoginToken(tinode.getAuthToken());
                                     UiUtils.onLoginSuccess(parent, signIn);
                                 }
                                 return null;

--- a/tinodesdk/src/main/java/co/tinode/tinodesdk/Tinode.java
+++ b/tinodesdk/src/main/java/co/tinode/tinodesdk/Tinode.java
@@ -337,9 +337,8 @@ public class Tinode {
                     mTopics.put(tt.getName(), tt);
                     setTopicsUpdated(tt.getUpdated());
                 }
-
-                mTopicsLoaded = true;
             }
+            mTopicsLoaded = true;
         }
     }
 


### PR DESCRIPTION
1. Tinode class doesn't set mAutoLogin in loginSuccessful. This is a way to handle it.
Alternatively, we can set mAutoLogin directly in loginSuccessful.
2. Tinode.mTopicsLoaded - the invariant is "true if Tinode.loadTopics() loaded all available topics from the internal storage into memory". Make sure it is set when the internal storage is empty.