### PR TITLE
Unsubscribe from background fetch only after the subscribe operation is complete

### DIFF
--- a/tinodesdk/src/main/java/co/tinode/tinodesdk/Topic.java
+++ b/tinodesdk/src/main/java/co/tinode/tinodesdk/Topic.java
@@ -454,8 +454,15 @@ public class Topic<DP, DR, SP, SR> implements LocalData, Comparable<Topic> {
             if (!isAttached()) {
                 try {
                     // Fully asynchronous fire and forget.
-                    subscribe(null, getMetaGetBuilder().withLaterData(limit).build(), true);
-                    leave();
+                    subscribe(null, getMetaGetBuilder().withLaterData(limit).build(), true).thenApply(
+                        new PromisedReply.SuccessListener<ServerMessage>() {
+                            @Override
+                            public PromisedReply<ServerMessage> onSuccess(ServerMessage msg) {
+                                leave();
+                                return null;
+                            }
+                        }
+                    );
                 } catch (Exception ex) {
                     Log.w(TAG, "Failed to sync data", ex);
                 }

--- a/tinodesdk/src/main/java/co/tinode/tinodesdk/Topic.java
+++ b/tinodesdk/src/main/java/co/tinode/tinodesdk/Topic.java
@@ -453,7 +453,6 @@ public class Topic<DP, DR, SP, SR> implements LocalData, Comparable<Topic> {
             // Fetch only if not attached. If it's attached it will be fetched elsewhere.
             if (!isAttached()) {
                 try {
-                    // Fully asynchronous fire and forget.
                     subscribe(null, getMetaGetBuilder().withLaterData(limit).build(), true).thenApply(
                         new PromisedReply.SuccessListener<ServerMessage>() {
                             @Override


### PR DESCRIPTION
Currently, `Topic.leave` gets called immediately after `Topic.subscribe` for background data fetches. As a result, the topic will try to unsubscribe before before a server response to the subscribe operation has been received - this results in no-op on the client. And the background subscription (if it actually succeeds later on) remains active until explicitly removed (e.g. the user opens this topic).