### PR TITLE
Fix foreign key violaiton in account deletion.

### DIFF
--- a/app/src/main/java/co/tinode/tindroid/db/TopicDb.java
+++ b/app/src/main/java/co/tinode/tindroid/db/TopicDb.java
@@ -501,6 +501,7 @@ public class TopicDb implements BaseColumns {
                     "SELECT " + _ID + " FROM " + TABLE_NAME + " WHERE " + COLUMN_NAME_ACCOUNT_ID + "=" + accId +
                 ")";
         db.execSQL(sql);
+        db.delete(TABLE_NAME, COLUMN_NAME_ACCOUNT_ID + "=" + accId, null);
     }
 
     /**


### PR DESCRIPTION
Topics table in SQLiteDb has a foreign key on the Accounts table.
We must delete all account's topics before deleting the account itself.