### PR TITLE
PrivateType parsing fix

### DIFF
--- a/tinodesdk/src/main/java/co/tinode/tinodesdk/model/PrivateType.java
+++ b/tinodesdk/src/main/java/co/tinode/tinodesdk/model/PrivateType.java
@@ -17,6 +17,16 @@ public class PrivateType extends HashMap<String,Object> implements Mergeable, Se
         super();
     }
 
+    public PrivateType(String text) {
+        super();
+        String[] splitted = text.split(":");
+        int counter = 0;
+        while (splitted.length % 2 == 0 && counter < splitted.length) {
+            put(splitted[counter], splitted[counter + 1]);
+            counter = counter + 2;
+        }
+    }
+
     @JsonIgnore
     private Object getValue(String name) {
         Object value = get(name);

--- a/tinodesdk/src/main/java/co/tinode/tinodesdk/model/PrivateType.java
+++ b/tinodesdk/src/main/java/co/tinode/tinodesdk/model/PrivateType.java
@@ -21,7 +21,7 @@ public class PrivateType extends HashMap<String,Object> implements Mergeable, Se
         super();
         String[] splitted = text.split(":");
         int counter = 0;
-        while (splitted.length % 2 == 0 && counter < splitted.length) {
+        while (splitted.length % 2 == 0 && counter < splitted.length - 1) {
             put(splitted[counter], splitted[counter + 1]);
             counter = counter + 2;
         }


### PR DESCRIPTION
Hello, there is a problem with PrivateType parsing:
2022-02-03 12:56:38.425 1741-1852/co.tinode.tindroid W/Tinode: Failed to deserialize network message
    com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot coerce empty String ("") to element of `co.tinode.tinodesdk.model.PrivateType` (but could if coercion was enabled using `CoercionConfig`)
        at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: co.tinode.tinodesdk.model.MsgServerMeta["sub"]->java.lang.Object[][0]->co.tinode.tinodesdk.model.Subscription["private"])
![image](https://user-images.githubusercontent.com/32201422/152320909-101a91d3-4c43-4914-97b4-91b64bc3ebc7.png)
