### PR TITLE
Video call state/duration moved to message headers.

### DIFF
--- a/app/src/main/java/co/tinode/tindroid/CallFragment.java
+++ b/app/src/main/java/co/tinode/tindroid/CallFragment.java
@@ -449,7 +449,6 @@ public class CallFragment extends Fragment {
             case OUTGOING:
                 // Send out a call invitation to the peer.
                 Map<String, Object> head = new HashMap<>();
-                head.put("mime", Tinode.VIDEO_CALL_MIME);
                 head.put("webrtc", "started");
                 mTopic.publish(Drafty.videoCall(), head).thenApply(new PromisedReply.SuccessListener<ServerMessage>() {
                     @Override

--- a/app/src/main/java/co/tinode/tindroid/CallFragment.java
+++ b/app/src/main/java/co/tinode/tindroid/CallFragment.java
@@ -450,7 +450,8 @@ public class CallFragment extends Fragment {
                 // Send out a call invitation to the peer.
                 Map<String, Object> head = new HashMap<>();
                 head.put("mime", Tinode.VIDEO_CALL_MIME);
-                mTopic.publish(new Drafty("started"), head).thenApply(new PromisedReply.SuccessListener<ServerMessage>() {
+                head.put("webrtc", "started");
+                mTopic.publish(Drafty.videoCall(), head).thenApply(new PromisedReply.SuccessListener<ServerMessage>() {
                     @Override
                     public PromisedReply<ServerMessage> onSuccess(ServerMessage result) {
                     if (result.ctrl != null && result.ctrl.code < 300) {

--- a/app/src/main/java/co/tinode/tindroid/ChatsAdapter.java
+++ b/app/src/main/java/co/tinode/tindroid/ChatsAdapter.java
@@ -282,8 +282,11 @@ public class ChatsAdapter extends RecyclerView.Adapter<ChatsAdapter.ViewHolder> 
                 }
                 Map<String, Object> head = msg.getHead();
                 PreviewFormatter fmt = new PreviewFormatter(priv.getContext(), priv.getTextSize());
-                if (head != null && UiUtils.isVideoCallMime((String)head.get("mime"))) {
-                    fmt.setVideoCallContext((String)head.get("webrtc"), msg.isMine());
+                if (head != null) {
+                    String webrtcState = (String)head.get("webrtc");
+                    if (webrtcState != null) {
+                        fmt.setVideoCallContext(webrtcState, msg.isMine());
+                    }
                 }
                 priv.setText(content.preview(MAX_MESSAGE_PREVIEW_LENGTH).format(fmt));
             } else {

--- a/app/src/main/java/co/tinode/tindroid/ChatsAdapter.java
+++ b/app/src/main/java/co/tinode/tindroid/ChatsAdapter.java
@@ -281,12 +281,11 @@ public class ChatsAdapter extends RecyclerView.Adapter<ChatsAdapter.ViewHolder> 
                     messageStatus.setVisibility(View.GONE);
                 }
                 Map<String, Object> head = msg.getHead();
-                if (head == null || !UiUtils.isVideoCallMime((String)head.get("mime"))) {
-                    priv.setText(content.preview(MAX_MESSAGE_PREVIEW_LENGTH)
-                            .format(new PreviewFormatter(priv.getContext(), priv.getTextSize())));
-                } else {
-                    priv.setText(UiUtils.videoCallMsg(priv.getContext(), msg.isMine(), msg.getContent().toString(), -1));
+                PreviewFormatter fmt = new PreviewFormatter(priv.getContext(), priv.getTextSize());
+                if (head != null && UiUtils.isVideoCallMime((String)head.get("mime"))) {
+                    fmt.setVideoCallContext((String)head.get("webrtc"), msg.isMine());
                 }
+                priv.setText(content.preview(MAX_MESSAGE_PREVIEW_LENGTH).format(fmt));
             } else {
                 messageStatus.setVisibility(View.GONE);
                 priv.setText(topic.getComment());

--- a/app/src/main/java/co/tinode/tindroid/MessagesAdapter.java
+++ b/app/src/main/java/co/tinode/tindroid/MessagesAdapter.java
@@ -652,8 +652,10 @@ public class MessagesAdapter extends RecyclerView.Adapter<MessagesAdapter.ViewHo
         // Disable clicker while message is processed.
         FullFormatter formatter = new FullFormatter(holder.mText, uploadingAttachment ? null : new SpanClicker(m.seq));
         formatter.setQuoteFormatter(new QuoteFormatter(holder.mText, holder.mText.getTextSize()));
-        if (UiUtils.isVideoCallMime(m.getStringHeader("mime"))) {
-            formatter.setVideoCallContext(display.getStringHeader("webrtc"), display.isMine(), display.getIntHeader("webrtc-duration", 0));
+        String webrtcState = display.getStringHeader("webrtc");
+        if (webrtcState != null) {
+            // It is a video call message. Set video call context.
+            formatter.setVideoCallContext(webrtcState, display.isMine(), display.getIntHeader("webrtc-duration", 0));
         }
         Spanned text = display.content.format(formatter);
 

--- a/app/src/main/java/co/tinode/tindroid/MessagesAdapter.java
+++ b/app/src/main/java/co/tinode/tindroid/MessagesAdapter.java
@@ -648,30 +648,14 @@ public class MessagesAdapter extends RecyclerView.Adapter<MessagesAdapter.ViewHo
         boolean uploadingAttachment = hasAttachment && display.isPending();
         boolean uploadFailed = hasAttachment && (display.status == BaseDb.Status.FAILED);
 
-        Spanned text;
-        if (!UiUtils.isVideoCallMime(m.getStringHeader("mime"))) {
-            // Normal message.
-            // Disable clicker while message is processed.
-            FullFormatter formatter = new FullFormatter(holder.mText, uploadingAttachment ? null : new SpanClicker(m.seq));
-            formatter.setQuoteFormatter(new QuoteFormatter(holder.mText, holder.mText.getTextSize()));
-            text = display.content.format(formatter);
-        } else {
-            // Video call.
-            long duration = -1;
-            TreeSet<StoredMessage> vers = mCursor.getVersions(seq);
-            if (vers != null) {
-                StoredMessage prev = null;
-                for (StoredMessage v : vers) {
-                    if (prev != null && "accepted".equals(prev.content.toString()) &&
-                            "finished".equals(v.content.toString())) {
-                        duration = v.ts.getTime() - prev.ts.getTime();
-                        break;
-                    }
-                    prev = v;
-                }
-            }
-            text = UiUtils.videoCallMsg(holder.itemView.getContext(), m.isMine(), display.content.toString(), (int)duration);
+        // Normal message.
+        // Disable clicker while message is processed.
+        FullFormatter formatter = new FullFormatter(holder.mText, uploadingAttachment ? null : new SpanClicker(m.seq));
+        formatter.setQuoteFormatter(new QuoteFormatter(holder.mText, holder.mText.getTextSize()));
+        if (UiUtils.isVideoCallMime(m.getStringHeader("mime"))) {
+            formatter.setVideoCallContext(display.getStringHeader("webrtc"), display.isMine(), display.getIntHeader("webrtc-duration", 0));
         }
+        Spanned text = display.content.format(formatter);
 
         if (text == null || text.length() == 0) {
             if (display.status == BaseDb.Status.DRAFT || display.status == BaseDb.Status.QUEUED || display.status == BaseDb.Status.SENDING) {

--- a/app/src/main/java/co/tinode/tindroid/UiUtils.java
+++ b/app/src/main/java/co/tinode/tindroid/UiUtils.java
@@ -536,11 +536,6 @@ public class UiUtils {
         return cont.append(sb);
     }
 
-    // Returns true if the specified mime type is a video call.
-    public static boolean isVideoCallMime(String mime) {
-        return Tinode.VIDEO_CALL_MIME.equals(mime);
-    }
-
     // If an incoming info is a video call related,
     public static void maybeHandleVideoCall(Context ctx, MsgServerInfo info) {
         if ("call".equals(info.what)) {

--- a/app/src/main/java/co/tinode/tindroid/UiUtils.java
+++ b/app/src/main/java/co/tinode/tindroid/UiUtils.java
@@ -34,7 +34,7 @@ import android.os.Parcelable;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.text.Spannable;
-import android.text.SpannableString;
+import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
@@ -520,9 +520,9 @@ public class UiUtils {
     // Builds and returns a video call message text given call direction, state and duration.
     // TODO: this should become a part of the Formatter interface.
     @NonNull
-    static Spanned videoCallMsg(Context context, boolean isOutgoing, String callState, int millis) {
+    public static SpannableStringBuilder videoCallMsg(Context context, boolean isOutgoing, String callState, int millis) {
         String dir = isOutgoing ? "↗" : "↙";
-        Spannable cont = new SpannableString(dir);
+        SpannableStringBuilder cont = new SpannableStringBuilder(dir);
         cont.setSpan(new ForegroundColorSpan(
                         "disconnected".equals(callState) ? Color.RED : Color.GREEN),
                 0, dir.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
@@ -533,7 +533,7 @@ public class UiUtils {
         if (millis > 0) {
             sb.append(" (" + millisToTime(millis) + ")");
         }
-        return (Spanned) TextUtils.concat(cont, sb.toString());
+        return cont.append(sb);
     }
 
     // Returns true if the specified mime type is a video call.

--- a/app/src/main/java/co/tinode/tindroid/format/AbstractDraftyFormatter.java
+++ b/app/src/main/java/co/tinode/tindroid/format/AbstractDraftyFormatter.java
@@ -61,8 +61,11 @@ public abstract class AbstractDraftyFormatter<T extends Spanned> implements Draf
     // Interactive form.
     protected abstract T handleForm(final Context ctx, List<T> content, final Map<String, Object> data);
 
-    // Interactive form.
+    // Quoted block.
     protected abstract T handleQuote(final Context ctx, List<T> content, final Map<String, Object> data);
+
+    // Video call.
+    protected abstract T handleVideoCall(final Context ctx, List<T> content, final Map<String, Object> data);
 
     // Unknown or unsupported element.
     protected abstract T handleUnknown(final Context ctx, List<T> content, final Map<String, Object> data);
@@ -133,6 +136,10 @@ public abstract class AbstractDraftyFormatter<T extends Spanned> implements Draf
                 case "QQ":
                     // Quoted block.
                     span = handleQuote(mContext, content, data);
+                    break;
+                case "VC":
+                    // Video call.
+                    span = handleVideoCall(mContext, content, data);
                     break;
                 default:
                     // Unknown element

--- a/app/src/main/java/co/tinode/tindroid/format/FullFormatter.java
+++ b/app/src/main/java/co/tinode/tindroid/format/FullFormatter.java
@@ -78,6 +78,11 @@ public class FullFormatter extends AbstractDraftyFormatter<SpannableStringBuilde
     private final ClickListener mClicker;
     private QuoteFormatter mQuoteFormatter;
 
+    // Video call related bits.
+    private String mCallState;
+    private boolean mCallIsOutgoing;
+    private int mCallDuration;
+
     public FullFormatter(final TextView container, final ClickListener clicker) {
         super(container.getContext());
 
@@ -111,6 +116,12 @@ public class FullFormatter extends AbstractDraftyFormatter<SpannableStringBuilde
 
     public void setQuoteFormatter(QuoteFormatter quoteFormatter) {
         mQuoteFormatter = quoteFormatter;
+    }
+
+    public void setVideoCallContext(String state, boolean isOutgoing, int duration) {
+        mCallState = state;
+        mCallIsOutgoing = isOutgoing;
+        mCallDuration = duration;
     }
 
     @Override
@@ -655,6 +666,11 @@ public class FullFormatter extends AbstractDraftyFormatter<SpannableStringBuilde
         SpannableStringBuilder node = handleQuote_Impl(ctx, content);
         // Increase spacing between the quote and the subsequent text.
         return node.append("\n\n", new RelativeSizeSpan(0.3f), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    }
+
+    @Override
+    protected SpannableStringBuilder handleVideoCall(Context ctx, List<SpannableStringBuilder> content, Map<String, Object> data) {
+        return UiUtils.videoCallMsg(ctx, mCallIsOutgoing, mCallState, mCallDuration);
     }
 
     // Unknown or unsupported element.

--- a/app/src/main/java/co/tinode/tindroid/format/PreviewFormatter.java
+++ b/app/src/main/java/co/tinode/tindroid/format/PreviewFormatter.java
@@ -21,15 +21,25 @@ import androidx.annotation.DrawableRes;
 import androidx.annotation.StringRes;
 import androidx.appcompat.content.res.AppCompatResources;
 import co.tinode.tindroid.R;
+import co.tinode.tindroid.UiUtils;
 
 // Drafty formatter for creating one-line message previews.
 public class PreviewFormatter extends AbstractDraftyFormatter<SpannableStringBuilder> {
     private final float mFontSize;
 
+    // Video call related bits.
+    private String mCallState;
+    private boolean mCallIsOutgoing;
+
     public PreviewFormatter(final Context context, float fontSize) {
         super(context);
 
         mFontSize = fontSize;
+    }
+
+    public void setVideoCallContext(String state, boolean isOutgoing) {
+        mCallState = state;
+        mCallIsOutgoing = isOutgoing;
     }
 
     @Override
@@ -168,6 +178,11 @@ public class PreviewFormatter extends AbstractDraftyFormatter<SpannableStringBui
     protected SpannableStringBuilder handleQuote(Context ctx, List<SpannableStringBuilder> content, Map<String, Object> data) {
         // Not showing quoted content in preview.
         return null;
+    }
+
+    @Override
+    protected SpannableStringBuilder handleVideoCall(Context ctx, List<SpannableStringBuilder> content, Map<String, Object> data) {
+        return UiUtils.videoCallMsg(ctx, mCallIsOutgoing, mCallState, -1);
     }
 
     @Override

--- a/app/src/main/java/co/tinode/tindroid/services/FBaseMessagingService.java
+++ b/app/src/main/java/co/tinode/tindroid/services/FBaseMessagingService.java
@@ -236,7 +236,7 @@ public class FBaseMessagingService extends FirebaseMessagingService {
                 String seqStr = data.get("seq");
                 try {
                     int seq = seqStr != null ? Integer.parseInt(seqStr) : 0;
-                    if (UiUtils.isVideoCallMime(data.get("mime")) && !tinode.isMe(senderId) && seq > 0) {
+                    if (data.get("webrtc") != null && !tinode.isMe(senderId) && seq > 0) {
                         // If it's a video call, start it.
                         if (data.get("replace") == null) {
                             UiUtils.handleIncomingVideoCall(this, "invite", topicName, senderId, seq);

--- a/tinodesdk/src/main/java/co/tinode/tinodesdk/Tinode.java
+++ b/tinodesdk/src/main/java/co/tinode/tinodesdk/Tinode.java
@@ -113,9 +113,6 @@ public class Tinode {
     protected static final TypeFactory sTypeFactory;
     protected static final SimpleDateFormat sDateFormat;
 
-    // Mime type of the Video call messages.
-    public static final String VIDEO_CALL_MIME = "application/x-tinode-webrtc";
-
     static {
         sJsonMapper = new ObjectMapper();
         // Silently ignore unknown properties

--- a/tinodesdk/src/main/java/co/tinode/tinodesdk/Topic.java
+++ b/tinodesdk/src/main/java/co/tinode/tinodesdk/Topic.java
@@ -1022,11 +1022,13 @@ public class Topic<DP, DR, SP, SR> implements LocalData, Comparable<Topic> {
             if (head == null) {
                 head = new HashMap<>();
             }
-            head.put("mime", Drafty.MIME_TYPE);
+            if (!Tinode.VIDEO_CALL_MIME.equals(head.get("mime"))) {
+                // Set "x-drafty" mime header (except video call messages.
+                head.put("mime", Drafty.MIME_TYPE);
+            }
             attachments = content.getEntReferences();
-        } else if (head != null && !Tinode.VIDEO_CALL_MIME.equals(head.get("mime"))) {
-            // Otherwise, plain text content should not have "mime" header
-            // (except video call messages). Clear it.
+        } else if (head != null) {
+            // Otherwise, plain text content should not have "mime" header. Clear it.
             head.remove("mime");
         }
         return mTinode.publish(getName(), content.isPlain() ? content.toString() : content, head, attachments).thenApply(
@@ -1074,7 +1076,7 @@ public class Topic<DP, DR, SP, SR> implements LocalData, Comparable<Topic> {
             if (extraHeaders != null) {
                 head.putAll(extraHeaders);
             }
-            if (!content.isPlain()) {
+            if (!content.isPlain() && !Tinode.VIDEO_CALL_MIME.equals(head.get("mime"))) {
                 head.put("mime", Drafty.MIME_TYPE);
             }
         } else {

--- a/tinodesdk/src/main/java/co/tinode/tinodesdk/Topic.java
+++ b/tinodesdk/src/main/java/co/tinode/tinodesdk/Topic.java
@@ -1022,10 +1022,7 @@ public class Topic<DP, DR, SP, SR> implements LocalData, Comparable<Topic> {
             if (head == null) {
                 head = new HashMap<>();
             }
-            if (!Tinode.VIDEO_CALL_MIME.equals(head.get("mime"))) {
-                // Set "x-drafty" mime header (except video call messages.
-                head.put("mime", Drafty.MIME_TYPE);
-            }
+            head.put("mime", Drafty.MIME_TYPE);
             attachments = content.getEntReferences();
         } else if (head != null) {
             // Otherwise, plain text content should not have "mime" header. Clear it.
@@ -1076,7 +1073,7 @@ public class Topic<DP, DR, SP, SR> implements LocalData, Comparable<Topic> {
             if (extraHeaders != null) {
                 head.putAll(extraHeaders);
             }
-            if (!content.isPlain() && !Tinode.VIDEO_CALL_MIME.equals(head.get("mime"))) {
+            if (!content.isPlain()) {
                 head.put("mime", Drafty.MIME_TYPE);
             }
         } else {

--- a/tinodesdk/src/main/java/co/tinode/tinodesdk/model/Drafty.java
+++ b/tinodesdk/src/main/java/co/tinode/tinodesdk/model/Drafty.java
@@ -828,6 +828,21 @@ public class Drafty implements Serializable {
     }
 
     /**
+     * Create a (self-contained) video call Drafty document.
+     * @return new Drafty representing a video call.
+     */
+    public static Drafty videoCall() {
+        Drafty d = new Drafty(" ");
+        d.fmt = new Style[]{
+                new Style(0, 1, 0)
+        };
+        d.ent = new Entity[]{
+                new Entity("VC")
+        };
+        return d;
+    }
+
+    /**
      * Wrap contents of the document into the specified style.
      * @param style to wrap document into.
      * @return 'this' Drafty document.


### PR DESCRIPTION
'webrtc' header for the state (started, accepted, finished, disconnected).
'webrtc-duration' header for call duration.
Call message rendering is now performed by the formatters.