### PR TITLE
fix camera message not work

### DIFF
--- a/app/src/main/java/co/tinode/tindroid/MessagesFragment.java
+++ b/app/src/main/java/co/tinode/tindroid/MessagesFragment.java
@@ -219,12 +219,13 @@ public class MessagesFragment extends Fragment {
 
                 final Intent data = result.getData();
                 final MessageActivity activity = (MessageActivity) getActivity();
-                if (data == null || activity == null || activity.isFinishing() || activity.isDestroyed()) {
+                // Image from the camera， data == null
+                if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
                     return;
                 }
 
                 final Bundle args = new Bundle();
-                if (data.getData() == null) {
+                if (data == null) {
                     // Image from the camera.
                     args.putString(AttachmentHandler.ARG_FILE_PATH, mCurrentPhotoFile);
                     args.putParcelable(AttachmentHandler.ARG_LOCAL_URI, mCurrentPhotoUri);


### PR DESCRIPTION
**Bug description**
When I select the picture from the camera, nothing happens

If the output path is specified, the data from intent will be null
`cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoUri);`

`final Intent data = result.getData();`