### PR TITLE
Update Drafty.java for counting surrogate chars

### DIFF
--- a/tinodesdk/src/main/java/co/tinode/tinodesdk/model/Drafty.java
+++ b/tinodesdk/src/main/java/co/tinode/tinodesdk/model/Drafty.java
@@ -419,6 +419,12 @@ public class Drafty implements Serializable {
 
             for (int i = 1; i<blks.size(); i++) {
                 int offset = text.codePointCount(0, text.length()) + 1;
+                for (int j = 0; j < text.length(); j++) {
+                    if (Character.isHighSurrogate(text.charAt(j)) && j + 1 < text.length() &&
+                        Character.isLowSurrogate(text.charAt(j + 1))){
+                            offset++;
+                    }
+                }
                 fmt.add(new Style("BR", offset - 1, 1));
 
                 b = blks.get(i);


### PR DESCRIPTION
A simple way to correct the offset when the text has an emoji. Related to #156 